### PR TITLE
Splitting single/multiple timers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     'max-classes-per-file': ['off'],
     'class-methods-use-this': ['off'],
     'import/prefer-default-export': ['off'],
+    'no-underscore-dangle': ['off'],
     'import/extensions': [
       'error',
       'ignorePackages',

--- a/app/anothjerFIle.js
+++ b/app/anothjerFIle.js
@@ -1,2 +1,2 @@
 /* eslint-disable no-console */
-console.log('aTexqwe t');
+console.log('aText');

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   "private": false,
   "scripts": {
     "build": "yarn tsc",
-    "run:dev": "DEBUG=ux:webpack_plugin webpack-dev-server --config ./webpack.config.dev.js",
-    "run:debug": "DEBUG=ux:webpack_plugin node --inspect-brk ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --config ./webpack.config.dev.js",
+    "run:dev": "DEBUG=ux:webpack_plugin* webpack-dev-server --config ./webpack.config.dev.js",
+    "run:debug": "DEBUG=ux:webpack_plugin* node --inspect-brk ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --config ./webpack.config.dev.js",
     "dev": "yarn build && yarn run:dev",
     "debug": "yarn build && yarn run:debug",
+    "watch": "yarn tsc --watch",
     "lint": "eslint --ext=.ts,.tsx src",
     "typecheck": "yarn tsc --noEmit"
   },

--- a/src/timer.ts
+++ b/src/timer.ts
@@ -1,4 +1,10 @@
 import { hrtime } from 'process';
+import debugFactory from 'debug';
+import {
+  DEBUG_STRING,
+} from './constants';
+
+const debug = debugFactory(`${DEBUG_STRING}:timer`);
 
 const diffingBigIntsToMilliseconds = (bigInt1: bigint, bigInt2: bigint) => {
   const substracted = (bigInt1 - bigInt2);
@@ -23,17 +29,20 @@ export class Timer {
   }
 
   start() {
+    debug('starting timer - "%s"', this.props.label);
     this.startTime = hrtime.bigint();
     this.started = true;
     this.isRunning = true;
   }
 
   stop() {
+    debug('stopping timer - "%s"', this.props.label);
     this.stopTime = hrtime.bigint();
     this.isRunning = false;
   }
 
   clear() {
+    debug('clearing timer - "%s"', this.props.label);
     this.startTime = BigInt(0);
     this.stopTime = BigInt(0);
     this.isRunning = false;
@@ -45,8 +54,12 @@ export class Timer {
       throw new Error(`Timer "${this.props.label}" was never started`);
     }
     if (this.isRunning) {
-      return diffingBigIntsToMilliseconds(hrtime.bigint(), this.startTime);
+      const milliseconds = diffingBigIntsToMilliseconds(hrtime.bigint(), this.startTime);
+      debug('TIME (in miliseconds) for "%s" => "%d miliseconds"', this.props.label, milliseconds);
+      return milliseconds;
     }
-    return diffingBigIntsToMilliseconds(this.stopTime, this.startTime);
+    const milliseconds = diffingBigIntsToMilliseconds(this.stopTime, this.startTime);
+    debug('TIME (in miliseconds) for "%s" => "%d miliseconds"', this.props.label, milliseconds);
+    return milliseconds;
   }
 }

--- a/src/timers.ts
+++ b/src/timers.ts
@@ -1,0 +1,52 @@
+import debugFactory from 'debug';
+import { v4 } from 'uuid';
+import { Timer } from './timer';
+import { DEBUG_STRING } from './constants';
+import { TrackingMetrics } from './types';
+
+const debug = debugFactory(`${DEBUG_STRING}:timers`);
+
+const timersMap = new Map<string, Timer>();
+
+const multiplerTimersIdCache = {
+  [TrackingMetrics.recompile]: new Set<string>(),
+  [TrackingMetrics.compile]: new Set<string>(),
+};
+
+const singleTimersIdCache = {
+  [TrackingMetrics.recompile_session]: null as string | null,
+  [TrackingMetrics.compile_session]: null as string | null,
+};
+
+const createAndAssignTimer = (id: string) => {
+  if (timersMap.has(id)) {
+    debug('There\'s already a timer for id %s', id);
+  }
+  const timer = new Timer(id);
+  timer.start();
+  timersMap.set(id, timer);
+};
+
+export const createTimer = (trackingMetric: 'recompile' | 'compile') => {
+  const key = v4();
+  createAndAssignTimer(`${trackingMetric} - ${key}`);
+  multiplerTimersIdCache[trackingMetric].add(key);
+  return key;
+};
+
+export const createSingleTimer = (trackingMetric: 'recompile_session' | 'compile_session') => {
+  const key = v4();
+  createAndAssignTimer(trackingMetric);
+  singleTimersIdCache[trackingMetric] = key;
+  return key;
+};
+
+export const getTimerMilliseconds = (key: string) => {
+  const timer = timersMap.get(key);
+  if (!timer) {
+    return null;
+  }
+  return timer.milliseconds();
+};
+
+export const getSingleTimerMilliseconds = (key: 'recompile_session' | 'compile_session') => getTimerMilliseconds(key);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { BufferedMetricsLoggerOptions } from 'datadog-metrics';
+import webpack from 'webpack';
 
 export type Full<T> = {
   [P in keyof T]-?: T[P];
@@ -21,3 +22,7 @@ export type DXWebpackPluginProps = {
 }
 
 export const trackingMetricKeys = Object.keys(TrackingMetrics) as TrackingMetricKeys[];
+
+export type UXPluginExtendedCompilation = webpack.compilation.Compilation & {
+  __id?: string;
+}

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -18,9 +18,26 @@ module.exports = {
     filename: fileName,
     publicPath: '/',
   },
-  watch: true,
-  watchOptions: {
-    ignored: '/node_modules/',
+  // watch: true,
+  // watchOptions: {
+  //   ignored: '/node_modules/',
+  // },
+  devServer: {
+    publicPath: '/',
+    hot: true,
+    historyApiFallback: {
+      index: '/',
+    },
+    onListening: (server) => {
+      // const port = server.listeningApp.address().port;
+      // const { localUrlForBrowser } = prepareUrls(
+      //   protocol,
+      //   HOST,
+      //   port || DEFAULT_PORT,
+      // );
+      // openBrowser(localUrlForBrowser);
+    },
+
   },
   resolve: {
     extensions: ['.js', '.jsx'],


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/952992/109744795-be64a380-7b87-11eb-80c0-cae8c5b528e1.png)

Webpack shows ~100ms of difference between the plugin and it's internal reporting. I think that's good enough :) 